### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-	"name": "jorm",
-	"description": "Simple orm - just orm",
-	"main": "./src/jorm",
-	"author": {
-		"name": "Alexey Talkan"
-	},
-	"scripts": {
-		"test": "./node_modules/.bin/mocha --reporter spec"
-	},
-	"version": "2.1.10",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/petrovi4/jorm.git"
-	},
-	"bugs": {
-		"url": "https://github.com/petrovi4/jorm/issues"
-	},
-	"devDependencies": {
-		"chai": "3.5.0",
-		"mocha": "2.5.3"
-	},
-	"readmeFilename": "README.md",
-	"homepage": "https://github.com/petrovi4/jorm",
-	"dependencies": {
-		"async": "1.2.1",
-		"extend": "1.2.1",
-		"lodash": "4.13.1",
-		"node-uuid": "1.4.3",
-		"pg": "6.0.2",
-		"sql": "git://github.com/petrovi4/node-sql.git#923b275dc0f3094a1560937ec45e8acdf324e64d"
-	}
+  "name": "jorm",
+  "description": "Simple orm - just orm",
+  "main": "./src/jorm",
+  "author": {
+    "name": "Alexey Talkan"
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/mocha --reporter spec"
+  },
+  "version": "2.1.10",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/petrovi4/jorm.git"
+  },
+  "bugs": {
+    "url": "https://github.com/petrovi4/jorm/issues"
+  },
+  "devDependencies": {
+    "chai": "3.5.0",
+    "mocha": "2.5.3"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/petrovi4/jorm",
+  "dependencies": {
+    "async": "1.2.1",
+    "extend": "1.2.1",
+    "lodash": "4.13.1",
+    "pg": "6.0.2",
+    "sql": "git://github.com/petrovi4/node-sql.git#923b275dc0f3094a1560937ec45e8acdf324e64d",
+    "uuid": "^3.0.0"
+  }
 }

--- a/src/essence.js
+++ b/src/essence.js
@@ -1,7 +1,7 @@
 var pg = require('pg');
 var async = require('async');
 var _ = require('lodash');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var crypto = require('crypto');
 
 var Essence = function(essenseType, params, alias) {	


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.